### PR TITLE
Fix settings caching and async client

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,6 +1,5 @@
 """Unit tests for the main FastAPI application."""
 
-from unittest.mock import Mock
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- remove default secret key and implement cache-aware `get_settings`
- create FastAPI app lazily and clean up `main`
- add validation for missing `secret_key`
- fix async test client fixture

## Testing
- `uv run ruff check .`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68672a9ed828832cb0369a533522875c